### PR TITLE
Updating some logic and fixing bugs

### DIFF
--- a/app/Http/Controllers/SlashIsIn.php
+++ b/app/Http/Controllers/SlashIsIn.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\SlackClient;
+use App\SlackMessage;
 use App\SlackUser;
 use DateTime;
 use Illuminate\Http\Request;
@@ -13,6 +14,7 @@ use Wgmv\SlackApi\Facades\SlackUser as SlackUserClient;
 
 class SlashIsIn extends Controller
 {
+    protected $replyMessage;
 
     public function __construct($teamId = null)
     {
@@ -20,6 +22,7 @@ class SlashIsIn extends Controller
         $this->teamId = $teamId ?? config('services.slack.team_id');
         $this->client = new SlackClient($this->teamId);
         $this->users = $this->client->getUsers();
+        $this->replyMessage = new SlackMessage;
     }
 
     public function __invoke(Request $request)
@@ -31,11 +34,11 @@ class SlashIsIn extends Controller
         // Slack escapes @mentions to look like <@U012ABCDEF>
         $pattern = "/\<@([\A-Z0-9]+)(?:\|[\w]+)?\>/";
         if (! preg_match_all($pattern, $message, $mentions)) {
-            return "Make sure you're including a username, like */IsIn @someone*";
+            return $this->reply("Make sure you're including a username, like */IsIn @someone*");
         }
 
         if (count($mentions[1]) > 1) {
-            return "Only mention one person, so I know who you're looking for! E.g. */IsIn @someone*";
+            return $this->reply("Only mention one person, so I know who you're looking for! E.g. */IsIn @someone*");
         }
 
         $userMentionedId = $mentions[1][0];
@@ -52,17 +55,26 @@ class SlashIsIn extends Controller
         $statusData = (new GetStaffIn())->getStatuses();
 
         if (array_get($statusData, 'status') != 'success') {
-            return "Sorry, something went wrong trying to look that up. Here's the error message:\n> " . array_get($statusData, 'message', '(No error message)');
+            return $this->reply(
+                "Sorry, something went wrong trying to look that up. Here's the error message:\n> "
+                . array_get($statusData, 'message', '(No error message)')
+            );
         }
 
         $statuses = collect(array_get($statusData, 'data.statuses'));
 
         // Get the status of the mentioned person
         if ($info = $statuses->get($userMentionedId)) {
-            return "@{$info['display_name']} is *@{$info['status']}*. Their last message in #general was {$info['since']}:\n> {$info['last_message']}";
-            $statuses->get($userMentionedId);
+            return $this->reply("@{$info['display_name']} is *@{$info['status']}*. Their last message in #general was {$info['since']}:\n> {$info['last_message']}");
         }
 
-        return "I've not seen @{$info['display_name']} in #general yet today, so you can assume they're *@out* right now.";
+        return $this->reply("I've not seen @{$info['display_name']} in #general yet today, so you can assume they're *@out* right now.");
+    }
+
+    protected function reply($text)
+    {
+        return $this->replyMessage
+            ->text($text)
+            ->toString();
     }
 }

--- a/app/Http/Controllers/SlashIsIn.php
+++ b/app/Http/Controllers/SlashIsIn.php
@@ -56,7 +56,7 @@ class SlashIsIn extends Controller
             $statusText = $statuses->map(function ($status) {
                 $emoji = [
                     'in' => '1:wave:',
-                    'out' => '4:peace:',
+                    'out' => '4:v:',
                     'lunch' => '3:bento:',
                     'break' => '2:coffee:',
                 ];

--- a/app/Http/Controllers/SlashIsIn.php
+++ b/app/Http/Controllers/SlashIsIn.php
@@ -43,14 +43,6 @@ class SlashIsIn extends Controller
 
         $userMentionedId = $mentions[1][0];
 
-        if ($userId == $userMentionedId) {
-            return Arr::random([
-                "Hey, wait a sec... You can't fool me! :robot_face:",
-                "I would think you'd know if you're in or out :thinking_face:",
-                "Maybe try tagging someone _else_ next time? :upside_down_face:",
-            ]);
-        }
-
         // Get the list of who's in
         $statusData = (new GetStaffIn())->getStatuses();
 

--- a/app/SlackClient.php
+++ b/app/SlackClient.php
@@ -5,9 +5,7 @@ namespace App;
 use App\Exceptions\SlackApiException;
 use DateTime;
 use Exception;
-use Wgmv\SlackApi\Facades\SlackApi;
 use Wgmv\SlackApi\Facades\SlackChannel;
-
 
 class SlackClient
 {
@@ -17,7 +15,7 @@ class SlackClient
     {
         $this->teamId = $teamId;
         $token = Token::where('team_id', $teamId)->first();
-        if (!$token) {
+        if (! $token) {
             throw new Exception("TeamID {$teamId} not authorized. Install app to Slack at " . url(), 401);
         }
     }
@@ -26,9 +24,11 @@ class SlackClient
     {
         return SlackUser::where('team_id', $this->teamId)
             ->get()
-            ->mapWithKeys(function ($user) {
-                return [$user->slack_id => $user];
-            });
+            ->mapWithKeys(
+                function ($user) {
+                    return [$user->slack_id => $user];
+                }
+            );
     }
 
     public function getMessagesFromToday($channelId)
@@ -51,14 +51,16 @@ class SlackClient
             );
 
             if ($data->ok == false) {
-                throw new SlackApiException("Slack API returned an error while fetching the channel history. Error ID " . $data->error . ". More info at https://api.slack.com/methods/channels.history");
+                throw new SlackApiException('Slack API returned an error while fetching the channel history. Error ID ' . $data->error . '. More info at https://api.slack.com/methods/channels.history');
             }
 
             $messages = collect($data->messages)
-                ->filter(function ($message) use ($earliestTime) {
-                    // Keeps messages after $earliestTime
-                    return (int)$message->ts >= $earliestTime;
-                });
+                ->filter(
+                    function ($message) use ($earliestTime) {
+                        // Keeps messages after $earliestTime
+                        return (int)$message->ts >= $earliestTime;
+                    }
+                );
 
             $lastMessageTs = $messages->last()->ts;
             $allMessages = $allMessages->merge($messages);

--- a/app/SlackMessage.php
+++ b/app/SlackMessage.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App;
+
+use function GuzzleHttp\json_encode;
+
+
+class SlackMessage
+{
+    public $text;
+    public $isMarkdown;
+
+    public function __construct($text = null, $isMarkdown = true)
+    {
+        $this->text = $text;
+        $this->isMarkdown = $isMarkdown;
+    }
+
+    public function text($text)
+    {
+        $this->text = $text;
+        return $this;
+    }
+
+    public function markdown()
+    {
+        $this->isMarkdown = true;
+        return $this;
+    }
+
+    public function plainText()
+    {
+        $this->isMarkdown = false;
+        return $this;
+    }
+
+    public function toString()
+    {
+        return $this->__toString();
+    }
+
+    public function __toString()
+    {
+        $message = [
+            'text' => $this->text,
+            'mrkdwn' => $this->isMarkdown,
+        ];
+
+        return json_encode($message);
+    }
+}


### PR DESCRIPTION
This PR fixes three issues:

* Fixes #3, now showing an earlier status message as the key message if the user's @brb status has since expired.
* Fixes #4, showing a list of all users' statuses keyed on (and sorted by) emoji:
  + 👋 in
  + ☕️ break
  + 🍱 lunch
  + ✌️ out
* Fixes #5, which now allows users to query their own status with `/isin`
